### PR TITLE
Added categories for unit tests: critical, regular

### DIFF
--- a/robot/build.gradle
+++ b/robot/build.gradle
@@ -119,4 +119,11 @@ tasks.withType(Test) {
             }
         }
     }
+
+    test {
+        useJUnit {
+            includeCategories 'us.ilite.CriticalTest'
+            excludeCategories 'us.ilite.RegularTest'
+        }
+    }
 }

--- a/robot/src/main/java/us/ilite/CriticalTest.java
+++ b/robot/src/main/java/us/ilite/CriticalTest.java
@@ -1,0 +1,4 @@
+package us.ilite;
+
+public interface CriticalTest {
+}

--- a/robot/src/main/java/us/ilite/RegularTest.java
+++ b/robot/src/main/java/us/ilite/RegularTest.java
@@ -1,0 +1,4 @@
+package us.ilite;
+
+public interface RegularTest {
+}

--- a/robot/src/test/java/us/ilite/robot/RobotUnitTest.java
+++ b/robot/src/test/java/us/ilite/robot/RobotUnitTest.java
@@ -1,11 +1,20 @@
 package us.ilite.robot;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import us.ilite.CriticalTest;
+import us.ilite.RegularTest;
 
+@Category(CriticalTest.class)
 public class RobotUnitTest {
 
     @Test
     public void testTestController() {
+    }
+    @Test
+    @Category(RegularTest.class)
+    public void testRegular() {
+
     }
 
 }


### PR DESCRIPTION
This allows us to annotate unit test classes and methods. Only critical tests will be run. This has only been done in the robot sub-project.