### PR TITLE
Refactored the auton-ui to not use reflection

### DIFF
--- a/robot/src/main/java/us/ilite/robot/auto/paths/AutonSelection.java
+++ b/robot/src/main/java/us/ilite/robot/auto/paths/AutonSelection.java
@@ -4,6 +4,7 @@ import com.team319.trajectory.Path;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import us.ilite.LazyReference;
 import us.ilite.robot.controller.*;
 
 import java.lang.reflect.InvocationTargetException;
@@ -11,15 +12,30 @@ import java.lang.reflect.InvocationTargetException;
 public class AutonSelection {
     public static ShuffleboardTab mAutonConfiguration = Shuffleboard.getTab("Auton Configuration");
     public static int mDelaySeconds;
-    private SendableChooser<Class<?>> mSendableAutonControllers = new SendableChooser<>();
+    private SendableChooser<AUTON_CONTROLLERS> mSendableAutonControllers = new SendableChooser<>();
 
-    /**
-     * Update these Auton Controllers whenever new ones are added
-     */
-    private Class<?>[] mAutonControllers = {
-            LineAutonController.class,
-            ShootIntakeController.class,
-    };
+    private enum AUTON_CONTROLLERS {
+        AUTON_CALIBRATION("Auton Calibration", new LazyReference<>(()->{
+            return new AutonCalibration();
+        })),
+        LINE_AUTON_CONTROLLER("Line Auton Controller",new LazyReference<>(()->{
+            return new LineAutonController();
+        })),
+        SHOOT_INTAKE_CONTROLLER("Shoot Auton Controller",new LazyReference<>(()->{
+            return new ShootIntakeController();
+        }));
+
+        private final String displayedName;
+        private final LazyReference<BaseAutonController> autonController;
+        private AUTON_CONTROLLERS(String displayedName, LazyReference<BaseAutonController> autonController) {
+            this.displayedName = displayedName;
+            this.autonController = autonController;
+        }
+
+        public BaseAutonController getAutonController() {
+            return autonController.getOrCompute();
+        }
+    }
 
     public AutonSelection() {
        mDelaySeconds = ((Double) (mAutonConfiguration.add("Path Delay Seconds", 0)
@@ -29,9 +45,10 @@ public class AutonSelection {
                .getDouble(0.0)))
                .intValue();
 
-        mSendableAutonControllers.setDefaultOption("Default - Auton Calibration", AutonCalibration.class);
-        for (Class<?> c : mAutonControllers) {
-            mSendableAutonControllers.addOption(c.getSimpleName(), c);
+        mSendableAutonControllers.setDefaultOption("Default - Auton Calibration", AUTON_CONTROLLERS.AUTON_CALIBRATION);
+
+        for(AUTON_CONTROLLERS auton_controllers : AUTON_CONTROLLERS.values()) {
+            mSendableAutonControllers.addOption(auton_controllers.displayedName ,auton_controllers);
         }
 
         mAutonConfiguration.add("Choose Auton Controller", mSendableAutonControllers)
@@ -40,18 +57,7 @@ public class AutonSelection {
     }
 
     public BaseAutonController getSelectedAutonController() {
-        try {
-            return (BaseAutonController) mSendableAutonControllers.getSelected().getDeclaredConstructor().newInstance();
-        } catch (NoSuchMethodException nsme) {
-            nsme.printStackTrace();
-        } catch (InstantiationException ie) {
-            ie.printStackTrace();
-        } catch (IllegalAccessException iae) {
-            iae.printStackTrace();
-        } catch (InvocationTargetException ite) {
-            ite.printStackTrace();
-        }
-        // THIS SHOULD NEVER BE REACHED
-        return null;
+
+        return mSendableAutonControllers.getSelected().autonController.getOrCompute();
     }
 }


### PR DESCRIPTION
@johnanselmo-s3i there are many reasons to not use refelction:

1. If the code changes so that there is no longer a constructor, the reflection will no longer work and we will always get into the null return. There will be no compile error to indicate this. 

1. Reflection can make it difficult to enumerate all of the possible values. 

1. Reflection isn't always allowed. I don't think we will ever implement a `SecurityManager` but if we do, the reflection will stop working.